### PR TITLE
Update download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ Keep your wireframes free of distracting Lorem Ipsum.
 ## Usage
 
 ### Download!
-<a href="/christiannaths/Redacted-Font/archive/old-sources.zip" class="minibutton sidebar-button" rel="nofollow">
-    <span class="octicon octicon-cloud-download"></span>
-    Download Redacted Font
-</a>
+
+[Download the Reacted Font](https://github.com/christiannaths/Redacted-Font/archive/old-sources.zip)
+
 
 ### Find the files you need!
 Look in the `fonts/` directory for the desktop fonts, and the `fonts/web/` directory for the web fonts.


### PR DESCRIPTION
Thanks for adding the dlownload link.

The link is expanded to https://github.com/christiannaths/Redacted-Font/blob/master/christiannaths/Redacted-Font/archive/old-sources.zip in my Chrome however, which doesn't work, so this PR adds the full URL.